### PR TITLE
Slope hitbox fix during mirror transition

### DIFF
--- a/src/MirrorShowHitboxesFix.cpp
+++ b/src/MirrorShowHitboxesFix.cpp
@@ -1,10 +1,34 @@
 #include <Geode/Geode.hpp>
+
+#if GEODE_COMP_GD_VERSION > 22000
+
 #include <Geode/modify/CCDrawNode.hpp>
+#include <Geode/modify/GJBaseGameLayer.hpp>
+#include <Geode/modify/GameObject.hpp>
 
 using namespace geode::prelude;
+
+static bool s_insideDebugUpdate = false;
 
 class $modify(cocos2d::CCDrawNode) {
     bool drawPolygon(CCPoint *verts, unsigned int count, const ccColor4F &fillColor, float borderWidth, const ccColor4F &borderColor) {
         return CCDrawNode::drawPolygon(verts, count, fillColor, std::abs(borderWidth), borderColor);
     }
 };
+
+class $modify(GJBaseGameLayer) {
+	void updateDebugDraw() {
+		s_insideDebugUpdate = true;
+		GJBaseGameLayer::updateDebugDraw();
+		s_insideDebugUpdate = false;
+	}
+};
+
+class $modify(GameObject) {
+	void determineSlopeDirection() {
+        if (s_insideDebugUpdate) return;
+        GameObject::determineSlopeDirection();
+	}
+};
+
+#endif

--- a/src/MirrorShowHitboxesFix.cpp
+++ b/src/MirrorShowHitboxesFix.cpp
@@ -17,18 +17,18 @@ class $modify(cocos2d::CCDrawNode) {
 };
 
 class $modify(GJBaseGameLayer) {
-	void updateDebugDraw() {
-		s_insideDebugUpdate = true;
-		GJBaseGameLayer::updateDebugDraw();
-		s_insideDebugUpdate = false;
-	}
+    void updateDebugDraw() {
+        s_insideDebugUpdate = true;
+        GJBaseGameLayer::updateDebugDraw();
+        s_insideDebugUpdate = false;
+    }
 };
 
 class $modify(GameObject) {
-	void determineSlopeDirection() {
+    void determineSlopeDirection() {
         if (s_insideDebugUpdate) return;
         GameObject::determineSlopeDirection();
-	}
+    }
 };
 
 #endif


### PR DESCRIPTION
Breakdown:  
`GameObject::determineSlopeDirection` is used, as you can guess from the name, to determine the slope orientation and flipped state. It hovewer does not return the value, but instead stores the states as GameObject members.
The issue now comes from the `GJBaseGameLayer::updateDebugDraw`, which calls this function if the object it wants to draw hitbox for is a slope. This changes the hitbox of the slope to it's horizontally flipped state very early and as a result makes the player die as if they hit the solid side of the slope. Note that this bug only occurs when hitboxes are visible.  
The fix simply disables that `GameObject::determineSlopeDirection` call, which fixes the issue.

Levels that can be tested:
* "Cataclysm" (3979721) - at 62% there is a ship transition with a mirror portal and a slope. With hitboxes on, the player would simply die.
* 104699183 - my tiny level which reproduces the issue more clearly


P.S. this pr also disables the fix for macOS, as 2.200 doesn't contain "Show hitboxes" option