### PR TITLE
Font highlight fix

### DIFF
--- a/src/FontChangeHighlightFix.cpp
+++ b/src/FontChangeHighlightFix.cpp
@@ -1,0 +1,14 @@
+#include <Geode/Geode.hpp>
+#include <Geode/modify/SelectFontLayer.hpp>
+
+using namespace geode::prelude;
+
+// fixes editor TextGameObject highlighting when changing fonts
+class $modify(FontChangeHighlightFix, SelectFontLayer) {
+    void onChangeFont(CCObject* sender) {
+        SelectFontLayer::onChangeFont(sender);
+        if (auto EUI = EditorUI::get()) {
+            EUI->resetSelectedObjectsColor();
+        }
+    }
+};


### PR DESCRIPTION
This pr addresses my pr (#19). Pretty much whenever you change fonts in the editor, every TextGameObject loses its selected color. I've found this a little annoying in the past. The fix here simply just calls EditorUI::resetSelectedObjectsColor(). Fix hasn't impacted performance in my testing. 

Side note: this fix doesn't account for the copy and paste select color; however, I think being able to tell when you've selected text is probably more important. This would also affect copy-and-paste objects outside of text objects, so if that needs to be addressed, I can also fix that. Most times this could be an issue tho I'd imagine the user has some text selected. 