### PR TITLE
fix cell glow being green if user last logged in pre-2.2

### DIFF
--- a/src/FixCellGlow.cpp
+++ b/src/FixCellGlow.cpp
@@ -12,7 +12,7 @@ class $modify(GJScoreCell) {
 		if (!simplePlayer)
 			return;
         
-        if (score->m_special == 2 && score->m_color3 >= 0)
+        if (score->m_special == 2 && score->m_color3 > 0)
 		    simplePlayer->setGlowOutline(GameManager::get()->colorForIdx(score->m_color3));
 	}
 };
@@ -25,7 +25,7 @@ class $modify(CommentCell) {
 		if (!simplePlayer)
 			return;
 		
-        if (comment->m_userScore->m_special == 2 && comment->m_userScore->m_color3 >= 0)
+        if (comment->m_userScore->m_special == 2 && comment->m_userScore->m_color3 > 0)
             simplePlayer->setGlowOutline(GameManager::get()->colorForIdx(comment->m_userScore->m_color3));
 	}
 };


### PR DESCRIPTION
if a user has glow enabled but hasn't logged into their account post-2.2 to update their glow color, it defaults to 0. however because this fix erroneously checks if `score->m_color3 >= 0` instead of `score->m_color3 > 0`, it sets the glow color to the default green color, which has an ID of 0.

before fix:
<img width="525" height="196" alt="image" src="https://github.com/user-attachments/assets/bebeb4b4-2fd7-45a6-adf3-0ea16820489a" />

after fix:
<img width="552" height="188" alt="image" src="https://github.com/user-attachments/assets/5fb79052-5445-40a1-9979-e0326b998e8c" />

expected glow color:
<img width="2233" height="1439" alt="image" src="https://github.com/user-attachments/assets/ffd5cf42-c704-44bc-990d-e908b6891916" />

_sidenote: if you set your glow color to that default green (with an ID of 0) and load a comment, this fix makes it erroneously use your secondary color as the glow color. however this behavior is consistent with the profile page and i don't think there's a way to fix this. you just can't set your glow color to that color i guess. kind of a silly oversight_